### PR TITLE
Avoid widowing the icon

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1,3 +1,6 @@
+.ILS.issue-link {
+	display: inline-block; /* Avoid widows on simple issue links #5 */
+}
 .ILS svg {
 	font-size: calc(1em / 14 * 8.125); /* Turn into em and make it 19% smaller */
 	vertical-align: -15%;


### PR DESCRIPTION
Fixes #5

This covers plain issue links, but not masked links (`[this issue](https://x.com/issues/5)`), those require some more markup to include, for example, the last couple of words of the linked sentences. `inline-block` would look bad on long linked sentences.