### PR TITLE
Replace periods in repo name

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -17,7 +17,7 @@ function anySelector(selector) {
 }
 
 function escapeForGql(repo) {
-	return repo.replace(/[/-]/g, '_');
+	return repo.replace(/[./-]/g, '_');
 }
 
 function buildGQL(links) {


### PR DESCRIPTION
Periods within a repo name need to be replaced or the GraphQL query fails.

For example, [this issue](https://github.com/julmot/mark.js/pull/177) is in the `mark.js` repo. The script creates an invalid query `repojulmot_mark.js`.
