### PR TITLE
Inherit styles for strike out text

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1,5 +1,6 @@
 .ILS.issue-link {
 	display: inline-block; /* Avoid widows on simple issue links #5 */
+	text-decoration: inherit; /* Inherit strike-through styling for <del> tags */
 }
 .ILS svg {
 	font-size: calc(1em / 14 * 8.125); /* Turn into em and make it 19% smaller */


### PR DESCRIPTION
Closes #20.

The `<a>` tag inside `<del>` by default has `text-decoration` set to `none`. This doesn't affect regular GH styling as there are no other nodes inside the link.

As we add additional nodes to the link, the styles for some reason, are no inherited, like the `text-decoration` property, but overridden. This change fixes that.