### PR TITLE
Pin XO version and lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     ],
     "rules": {
       "import/no-unassigned-import": 0
+    },
+    "parserOptions": {
+      "ecmaVersion": 2019
     }
   },
   "dependencies": {
@@ -30,6 +33,6 @@
     "web-ext-submit": "^3.1.1",
     "webpack": "^4.39.1",
     "webpack-cli": "^3.3.6",
-    "xo": "*"
+    "xo": "^0.25.3"
   }
 }

--- a/source/content.js
+++ b/source/content.js
@@ -114,7 +114,7 @@ async function apply() {
 			if (state !== 'open' && state + type !== 'closedpullrequest') {
 				link.querySelector('svg').outerHTML = icons[state + type];
 			}
-		} catch (error) {/* Probably a redirect */}
+		} catch {/* Probably a redirect */}
 	}
 }
 


### PR DESCRIPTION
`*` for `xo`s version creates a moving target for new PRs. Pinning it solves the problem.