### PR TITLE
Social distancing for icons

### DIFF
--- a/source/github-issue-link-status.css
+++ b/source/github-issue-link-status.css
@@ -5,7 +5,7 @@
 .ILS svg {
 	font-size: calc(1em / 14 * 8.125); /* Turn into em and make it 19% smaller */
 	vertical-align: -15%;
-	margin-left: 0.2em;
+	margin-left: 0.3em;
 }
 .ILS + .ILS {
 	margin-left: 0.1em;


### PR DESCRIPTION
0.2em of spacing is too tight for the circular issue icon when combined with digits that are "right-leaning", like '7' or '3'. Changed to a slightly wider 0.3em.

The difference is very subtle, but I think it helps.

| Before | After |
|--------|-------|
|![Screenshot 2020-11-20 at 16 06 34](https://user-images.githubusercontent.com/478237/99835911-340aad80-2b5d-11eb-890f-3b351ca6702d.png)|![Screenshot 2020-11-20 at 16 09 23](https://user-images.githubusercontent.com/478237/99835916-366d0780-2b5d-11eb-89db-541f10d08a90.png)|

| Before | After |
|--------|-------|
|![Screenshot 2020-11-20 at 16 10 04](https://user-images.githubusercontent.com/478237/99835945-4258c980-2b5d-11eb-908d-22b473b74383.png)|![Screenshot 2020-11-20 at 16 09 48](https://user-images.githubusercontent.com/478237/99835940-408f0600-2b5d-11eb-8fbb-889d8b8f4197.png)|

