### PR TITLE
Fixed missing "enable on this domain" option

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -27,7 +27,7 @@
 		"activeTab",
 		"https://api.github.com/*"
 	],
-	"optional_permissions": ["http://*/*", "https://*/*"],
+	"optional_permissions": ["*://*/*"],
 	"options_ui": {
 		"chrome_style": true,
 		"page": "options.html"


### PR DESCRIPTION
In the current version, chrome doesn't give you the "enable on this domain" option when using github enterprise. This minor adjustment to the manifest does the trick.