### PR TITLE
Accept the new token format in the options

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -19,7 +19,7 @@
 			name="token"
 			spellcheck="false"
 			autocomplete="off"
-			pattern="gp1_[\da-zA-Z_]{36,251}"
+			pattern="([\da-f]{40})|(gp1_\w{36,251})"
 			required
 		/>
 	</p>

--- a/source/options.html
+++ b/source/options.html
@@ -19,7 +19,7 @@
 			name="token"
 			spellcheck="false"
 			autocomplete="off"
-			pattern="gp1_[\da-zA-Z_]{36}"
+			pattern="gp1_[\da-zA-Z_]{36,251}"
 			required
 		/>
 	</p>

--- a/source/options.html
+++ b/source/options.html
@@ -19,7 +19,7 @@
 			name="token"
 			spellcheck="false"
 			autocomplete="off"
-			pattern="[\da-f]{40}"
+			pattern="gp1_[\da-zA-Z_]{36}"
 			required
 		/>
 	</p>

--- a/source/options.html
+++ b/source/options.html
@@ -19,7 +19,7 @@
 			name="token"
 			spellcheck="false"
 			autocomplete="off"
-			pattern="([\da-f]{40})|(gp1_\w{36,251})"
+			pattern="[\da-f]{40}|gp1_\w{36,251}"
 			required
 		/>
 	</p>


### PR DESCRIPTION
Fixes #45

The new pattern matches the prefix for Personal Access Tokens.  It will also accept the new token length of up to 255 characters after June 1.  