### PR TITLE
uses @primer/octicons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 			"devDependencies": {
 				"@parcel/config-webextension": "^2.0.0-rc.0",
 				"@parcel/transformer-image": "^2.0.0-rc.0",
+				"@parcel/transformer-inline-string": "^2.0.0-rc.0",
 				"bundlewatch": "^0.3.2",
 				"parcel": "^2.0.0-rc.0",
 				"xo": "^0.44.0"
@@ -1755,6 +1756,23 @@
 			"engines": {
 				"node": ">= 12.0.0",
 				"parcel": "^2.0.0-beta.1"
+			}
+		},
+		"node_modules/@parcel/transformer-inline-string": {
+			"version": "2.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-inline-string/-/transformer-inline-string-2.0.0-rc.0.tgz",
+			"integrity": "sha512-i5dpBey+9BFU24KEuCPz0N22Ph6UiAoYk/41Vl1yumXWKSaA3MbmICEIbHGRCf4XErFI7f7LIY+U0UU6kWLgEA==",
+			"dev": true,
+			"dependencies": {
+				"@parcel/plugin": "2.0.0-rc.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0",
+				"parcel": "^2.0.0-beta.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-js": {
@@ -16163,6 +16181,15 @@
 				"sharp": "^0.28.3"
 			}
 		},
+		"@parcel/transformer-inline-string": {
+			"version": "2.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-inline-string/-/transformer-inline-string-2.0.0-rc.0.tgz",
+			"integrity": "sha512-i5dpBey+9BFU24KEuCPz0N22Ph6UiAoYk/41Vl1yumXWKSaA3MbmICEIbHGRCf4XErFI7f7LIY+U0UU6kWLgEA==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "2.0.0-rc.0"
+			}
+		},
 		"@parcel/transformer-js": {
 			"version": "2.0.0-rc.0",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.0.0-rc.0.tgz",
@@ -19182,7 +19209,9 @@
 			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.44.0.tgz",
 			"integrity": "sha512-/mRj2KHHwnl3ZyM8vn68NSfRoEunkSYagWERGmNnU5UOLo4AY9jjBNZW+/sDOaPYuc5xzYmLxYspDCVCXKLGNQ==",
 			"dev": true,
-			"requires": {}
+			"requires": {
+				"typescript": ">=4.3"
+			}
 		},
 		"eslint-formatter-pretty": {
 			"version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"packages": {
 		"": {
 			"dependencies": {
+				"@primer/octicons": "^16.1.1",
 				"webext-base-css": "^1.3.2",
 				"webext-domain-permission-toggle": "^2.1.0",
 				"webext-dynamic-content-scripts": "^8.0.0",
@@ -2210,6 +2211,14 @@
 			},
 			"peerDependencies": {
 				"@parcel/core": "^2.0.0-alpha.3.1"
+			}
+		},
+		"node_modules/@primer/octicons": {
+			"version": "16.1.1",
+			"resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-16.1.1.tgz",
+			"integrity": "sha512-qlMErXg4I7oOofP4d5GceLbNpjTRSkyLoe5Ng1mfebtTvjeBj8x+kdqgwFWLRp7QO1ye5AaxcCvn1AJMAeURzw==",
+			"dependencies": {
+				"object-assign": "^4.1.1"
 			}
 		},
 		"node_modules/@swc/helpers": {
@@ -9940,7 +9949,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -16487,6 +16495,14 @@
 				"nullthrows": "^1.1.1"
 			}
 		},
+		"@primer/octicons": {
+			"version": "16.1.1",
+			"resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-16.1.1.tgz",
+			"integrity": "sha512-qlMErXg4I7oOofP4d5GceLbNpjTRSkyLoe5Ng1mfebtTvjeBj8x+kdqgwFWLRp7QO1ye5AaxcCvn1AJMAeURzw==",
+			"requires": {
+				"object-assign": "^4.1.1"
+			}
+		},
 		"@swc/helpers": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.13.tgz",
@@ -19166,9 +19182,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.44.0.tgz",
 			"integrity": "sha512-/mRj2KHHwnl3ZyM8vn68NSfRoEunkSYagWERGmNnU5UOLo4AY9jjBNZW+/sDOaPYuc5xzYmLxYspDCVCXKLGNQ==",
 			"dev": true,
-			"requires": {
-				"typescript": ">=4.3"
-			}
+			"requires": {}
 		},
 		"eslint-formatter-pretty": {
 			"version": "4.1.0",
@@ -22464,8 +22478,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		}
 	},
 	"dependencies": {
+		"@primer/octicons": "^16.1.1",
 		"webext-base-css": "^1.3.2",
 		"webext-domain-permission-toggle": "^2.1.0",
 		"webext-dynamic-content-scripts": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	"devDependencies": {
 		"@parcel/config-webextension": "^2.0.0-rc.0",
 		"@parcel/transformer-image": "^2.0.0-rc.0",
+		"@parcel/transformer-inline-string": "^2.0.0-rc.0",
 		"bundlewatch": "^0.3.2",
 		"parcel": "^2.0.0-rc.0",
 		"xo": "^0.44.0"

--- a/source/github-issue-link-status.js
+++ b/source/github-issue-link-status.js
@@ -13,6 +13,10 @@ const stateColorMap = {
 	merged: ['text-purple', 'color-purple-5'],
 };
 
+function addOcticonClass(svgString) {
+	return svgString?.replace('<svg', '<svg class="octicon"');
+}
+
 function anySelector(selector) {
 	const prefix = document.head.style.MozOrient === '' ? 'moz' : 'webkit';
 	return selector.replace(/:any\(/g, `:-${prefix}-any(`);
@@ -95,7 +99,7 @@ async function apply() {
 	}
 
 	for (const {link, type} of links) {
-		link.insertAdjacentHTML('beforeEnd', icons['open' + type]);
+		link.insertAdjacentHTML('beforeEnd', addOcticonClass(icons['open' + type]));
 	}
 
 	const query = buildGQL(links);
@@ -122,9 +126,9 @@ async function apply() {
 			link.classList.add(...stateColorMap[state]);
 
 			if (item.isDraft && state === 'open') {
-				link.querySelector('svg').outerHTML = icons['draft' + type];
+				link.querySelector('svg').outerHTML = addOcticonClass(icons['draft' + type]);
 			} else {
-				link.querySelector('svg').outerHTML = icons[state + type];
+				link.querySelector('svg').outerHTML = addOcticonClass(icons[state + type]);
 			}
 		} catch {/* Probably a redirect */}
 	}

--- a/source/icons.js
+++ b/source/icons.js
@@ -3,14 +3,13 @@ import octicons from '@primer/octicons';
 export const openissue = octicons['issue-opened'].toSVG();
 
 export const closedissue = octicons['issue-closed'].toSVG();
-//issue-closed
+
 export const draftissue = octicons['issue-draft'].toSVG();
-//issue-draft
+
 export const openpullrequest = octicons['git-pull-request'].toSVG();
-//git-pull-request
+
 export const mergedpullrequest = octicons['git-merge'].toSVG();
-//git-merge
+
 export const closedpullrequest = octicons['git-pull-request-closed'].toSVG();
-//git-pull-request-closed
+
 export const draftpullrequest = octicons['git-pull-request-draft'].toSVG();
-//git-pull-request-draft

--- a/source/icons.js
+++ b/source/icons.js
@@ -1,15 +1,8 @@
-import octicons from '@primer/octicons';
-
-export const openissue = octicons['issue-opened'].toSVG();
-
-export const closedissue = octicons['issue-closed'].toSVG();
-
-export const draftissue = octicons['issue-draft'].toSVG();
-
-export const openpullrequest = octicons['git-pull-request'].toSVG();
-
-export const mergedpullrequest = octicons['git-merge'].toSVG();
-
-export const closedpullrequest = octicons['git-pull-request-closed'].toSVG();
-
-export const draftpullrequest = octicons['git-pull-request-draft'].toSVG();
+export {default as options} from './options-storage.js';
+export {default as openissue} from 'bundle-text:@primer/octicons/build/svg/issue-opened-16.svg';
+export {default as closedissue} from 'bundle-text:@primer/octicons/build/svg/issue-closed-16.svg';
+export {default as draftissue} from 'bundle-text:@primer/octicons/build/svg/issue-draft-16.svg';
+export {default as openpullrequest} from 'bundle-text:@primer/octicons/build/svg/git-pull-request-16.svg';
+export {default as mergedpullrequest} from 'bundle-text:@primer/octicons/build/svg/git-merge-16.svg';
+export {default as closedpullrequest} from 'bundle-text:@primer/octicons/build/svg/git-pull-request-closed-16.svg';
+export {default as draftpullrequest} from 'bundle-text:@primer/octicons/build/svg/git-pull-request-draft-16.svg';

--- a/source/icons.js
+++ b/source/icons.js
@@ -1,13 +1,16 @@
-export const openissue = '<svg class="octicon octicon-issue-opened open" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></svg>';
+import octicons from '@primer/octicons';
 
-export const closedissue = '<svg class="octicon octicon-issue-closed closed" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M11.28 6.78a.75.75 0 00-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 00-1.06 1.06l2 2a.75.75 0 001.06 0l3.5-3.5z"/><path fill-rule="evenodd" d="M16 8A8 8 0 110 8a8 8 0 0116 0zm-1.5 0a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z"/></svg>';
+export const openissue = octicons['issue-opened'].toSVG();
 
-export const draftissue = '<svg class="octicon octicon-issue-draft color-text-tertiary" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M6.749.097a8.054 8.054 0 012.502 0 .75.75 0 11-.233 1.482 6.554 6.554 0 00-2.036 0A.75.75 0 016.749.097zM4.345 1.693A.75.75 0 014.18 2.74a6.542 6.542 0 00-1.44 1.44.75.75 0 01-1.212-.883 8.042 8.042 0 011.769-1.77.75.75 0 011.048.166zm7.31 0a.75.75 0 011.048-.165 8.04 8.04 0 011.77 1.769.75.75 0 11-1.214.883 6.542 6.542 0 00-1.439-1.44.75.75 0 01-.165-1.047zM.955 6.125a.75.75 0 01.624.857 6.554 6.554 0 000 2.036.75.75 0 01-1.482.233 8.054 8.054 0 010-2.502.75.75 0 01.858-.624zm14.09 0a.75.75 0 01.858.624 8.057 8.057 0 010 2.502.75.75 0 01-1.482-.233 6.55 6.55 0 000-2.036.75.75 0 01.624-.857zm-13.352 5.53a.75.75 0 011.048.165 6.542 6.542 0 001.439 1.44.75.75 0 01-.883 1.212 8.04 8.04 0 01-1.77-1.769.75.75 0 01.166-1.048zm12.614 0a.75.75 0 01.165 1.048 8.038 8.038 0 01-1.769 1.77.75.75 0 11-.883-1.214 6.543 6.543 0 001.44-1.439.75.75 0 011.047-.165zm-8.182 3.39a.75.75 0 01.857-.624 6.55 6.55 0 002.036 0 .75.75 0 01.233 1.482 8.057 8.057 0 01-2.502 0 .75.75 0 01-.624-.858z"/></svg>';
-
-export const openpullrequest = '<svg class="octicon octicon-git-pull-request open" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>';
-
-export const mergedpullrequest = '<svg class="octicon octicon-git-merge merged" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M5 3.254V3.25v.005a.75.75 0 110-.005v.004zm.45 1.9a2.25 2.25 0 10-1.95.218v5.256a2.25 2.25 0 101.5 0V7.123A5.735 5.735 0 009.25 9h1.378a2.251 2.251 0 100-1.5H9.25a4.25 4.25 0 01-3.8-2.346zM12.75 9a.75.75 0 100-1.5.75.75 0 000 1.5zm-8.5 4.5a.75.75 0 100-1.5.75.75 0 000 1.5z"/></svg>';
-
-export const closedpullrequest = '<svg class="octicon octicon-git-pull-request-closed closed" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M10.72 1.227a.75.75 0 011.06 0l.97.97.97-.97a.75.75 0 111.06 1.061l-.97.97.97.97a.75.75 0 01-1.06 1.06l-.97-.97-.97.97a.75.75 0 11-1.06-1.06l.97-.97-.97-.97a.75.75 0 010-1.06zM12.75 6.5a.75.75 0 00-.75.75v3.378a2.251 2.251 0 101.5 0V7.25a.75.75 0 00-.75-.75zm0 5.5a.75.75 0 100 1.5.75.75 0 000-1.5zM2.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.25 1a2.25 2.25 0 00-.75 4.372v5.256a2.251 2.251 0 101.5 0V5.372A2.25 2.25 0 003.25 1zm0 11a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>';
-
-export const draftpullrequest = '<svg class="octicon octicon-git-pull-request-draft color-text-tertiary" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M2.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.25 1a2.25 2.25 0 00-.75 4.372v5.256a2.251 2.251 0 101.5 0V5.372A2.25 2.25 0 003.25 1zm0 11a.75.75 0 100 1.5.75.75 0 000-1.5zm9.5 3a2.25 2.25 0 100-4.5 2.25 2.25 0 000 4.5zm0-3a.75.75 0 100 1.5.75.75 0 000-1.5z"/><path d="M14 7.5a1.25 1.25 0 11-2.5 0 1.25 1.25 0 012.5 0zm0-4.25a1.25 1.25 0 11-2.5 0 1.25 1.25 0 012.5 0z"/></svg>';
+export const closedissue = octicons['issue-closed'].toSVG();
+//issue-closed
+export const draftissue = octicons['issue-draft'].toSVG();
+//issue-draft
+export const openpullrequest = octicons['git-pull-request'].toSVG();
+//git-pull-request
+export const mergedpullrequest = octicons['git-merge'].toSVG();
+//git-merge
+export const closedpullrequest = octicons['git-pull-request-closed'].toSVG();
+//git-pull-request-closed
+export const draftpullrequest = octicons['git-pull-request-draft'].toSVG();
+//git-pull-request-draft


### PR DESCRIPTION
Resolves #59

It now uses 16.1.1 of @primer/octicons 

The below screenshot is from [here](https://github.com/fregante/github-issue-link-status/issues/57) and works as earlier.

> ![screenshot](https://user-images.githubusercontent.com/60680215/139317587-227d407c-de5b-496a-abe7-8f82c30df589.JPG)

