### PR TITLE
Color closed issues purple and update classes

### DIFF
--- a/source/github-issue-link-status.js
+++ b/source/github-issue-link-status.js
@@ -8,9 +8,15 @@ const endpoint = location.hostname === 'github.com'
 	: `${location.origin}/api/graphql`;
 const issueUrlRegex = /^[/]([^/]+[/][^/]+)[/](issues|pull)[/](\d+)([/]|$)/;
 const stateColorMap = {
-	open: ['text-green', 'color-text-success'],
-	closed: ['text-red', 'color-text-danger'],
-	merged: ['text-purple', 'color-purple-5'],
+	pullrequest: {
+		open: ['text-green', 'color-text-success'],
+		closed: ['text-red', 'color-text-danger'],
+		merged: ['text-purple', 'color-purple-5']
+	},
+	issue: {
+		open: ['text-green', 'color-text-success'],
+		closed: ['text-purple', 'color-purple-5'],
+	}
 };
 
 function anySelector(selector) {
@@ -119,7 +125,7 @@ async function apply() {
 			const type = item.__typename.toLowerCase();
 			const state = item.state.toLowerCase();
 
-			link.classList.add(...stateColorMap[state]);
+			link.classList.add(...stateColorMap[type][state]);
 
 			if (item.isDraft && state === 'open') {
 				link.querySelector('svg').outerHTML = icons['draft' + type];

--- a/source/github-issue-link-status.js
+++ b/source/github-issue-link-status.js
@@ -9,13 +9,13 @@ const endpoint = location.hostname === 'github.com'
 const issueUrlRegex = /^[/]([^/]+[/][^/]+)[/](issues|pull)[/](\d+)([/]|$)/;
 const stateColorMap = {
 	pullrequest: {
-		open: ['text-green', 'color-text-success'],
-		closed: ['text-red', 'color-text-danger'],
-		merged: ['text-purple', 'color-purple-5'],
+		open: ['text-green', 'color-text-success', 'color-fg-success'],
+		closed: ['text-red', 'color-text-danger', 'color-fg-danger'],
+		merged: ['text-purple', 'color-purple-5', 'color-fg-done'],
 	},
 	issue: {
-		open: ['text-green', 'color-text-success'],
-		closed: ['text-purple', 'color-purple-5'],
+		open: ['text-green', 'color-text-success', 'color-fg-success'],
+		closed: ['text-purple', 'color-purple-5', 'color-fg-done'],
 	},
 };
 

--- a/source/github-issue-link-status.js
+++ b/source/github-issue-link-status.js
@@ -11,12 +11,12 @@ const stateColorMap = {
 	pullrequest: {
 		open: ['text-green', 'color-text-success'],
 		closed: ['text-red', 'color-text-danger'],
-		merged: ['text-purple', 'color-purple-5']
+		merged: ['text-purple', 'color-purple-5'],
 	},
 	issue: {
 		open: ['text-green', 'color-text-success'],
 		closed: ['text-purple', 'color-purple-5'],
-	}
+	},
 };
 
 function anySelector(selector) {


### PR DESCRIPTION
Also, a bit of a refactor to the state color map to make it less complicated when adding more states for types. I don't know if this is related to my changes, but when I ran the extension locally, it seemed to not show the purple color for the links to closed issues. Looking at some screenshots and issues, this seems to be the current behavior. Is this expected?

Fixes #64